### PR TITLE
Revert change that broke Quora UI

### DIFF
--- a/easylist/easylist_specific_hide.txt
+++ b/easylist/easylist_specific_hide.txt
@@ -4397,7 +4397,7 @@ breakingnews.ie,canberratimes.com.au,theland.com.au##.py-2.bg-gray-100
 fastcompany.com##.py-8
 onlyinyourstate.com##.py-8.md\:flex
 pymnts.com##.pymnt_ads
-quora.com##.q-sticky[style*="box-sizing: border-box; position: sticky;"]
+quora.com##.PageContentsLayout___StyledBox-d2uxks-0 > .q-box > .q-sticky > .qu-pb--medium
 euronews.com##.qa-dfpLeaderBoard
 infoq.com##.qcon_banner
 thegatewaypundit.com##.qh1aqgd


### PR DESCRIPTION
Hi team,

The change made in https://github.com/easylist/easylist/commit/0f775ba709921ae65d618eaa026589ddf7bb5b32#diff-d95e1ad0368a5fb3bacb89fc7f209b9fa33a9974d9d2cf4b9a98903b7aa356a2R4400 broke Quora UI. In particular it hides the button that allow users to post an answer / question / post on the site.

Screenshot:

- Post button is hidden because of `display: none !important` set in user agent stylesheet.
<img width="1898" alt="Screenshot 2025-01-07 at 7 54 46 PM" src="https://github.com/user-attachments/assets/90cc9364-942b-46d1-9c7b-82bb8d52b6ca" />

- Post button shown after overriding the `display` property in browser 
<img width="1898" alt="Screenshot 2025-01-07 at 7 56 27 PM" src="https://github.com/user-attachments/assets/5372d26d-51e7-49ac-a0f9-07679fe2d5f5" />
